### PR TITLE
2 things has been fixed

### DIFF
--- a/freepbx-install.sh
+++ b/freepbx-install.sh
@@ -112,7 +112,7 @@ chown -R asterisk. /var/{lib,log,spool}/asterisk
 chown -R asterisk. /usr/lib64/asterisk
 chown -R asterisk. /var/www/
 
-sed -i 's/\(^upload_max_filesize = \).*/\256M/' /etc/php.ini
+sed -i 's/\(^upload_max_filesize = \).*/\1 256M/' /etc/php.ini
 sed -i 's/^\(User\|Group\).*/\1 asterisk/' /etc/httpd/conf/httpd.conf
 sed -i 's/AllowOverride None/AllowOverride All/' /etc/httpd/conf/httpd.conf
 service httpd restart

--- a/freepbx-install.sh
+++ b/freepbx-install.sh
@@ -77,7 +77,8 @@ tar xvfz asterisk-13-current.tar.gz
 rm -f asterisk-13-current.tar.gz
 cd asterisk-*
 contrib/scripts/install_prereq install
-./configure --libdir=/usr/lib64 --enable-sanitize=memory
+# --with-pjproject-bundled -> https://blogs.asterisk.org/2016/03/16/asterisk-13-8-0-now-easier-pjsip-install-method/
+./configure --libdir=/usr/lib64 --enable-sanitize=memory --with-pjproject-bundled
 contrib/scripts/get_mp3_source.sh
 wait ${!}
 make menuselect.makeopts 


### PR DESCRIPTION
1) now asterisk chould be configured with --with-pjproject-bundled - otherwise on 13.22 it's giving errors:
```
[azavyalov@gfm-production-voip0 asterisk-13.22.0]$ sudo make
CC="cc" CXX="g++" LD="" AR="" RANLIB="" CFLAGS="" LDFLAGS="" make -C menuselect CONFIGURE_SILENT="--silent" makeopts
make[1]: Entering directory `/usr/src/asterisk-13.22.0/menuselect'
make[1]: `makeopts' is up to date.
make[1]: Leaving directory `/usr/src/asterisk-13.22.0/menuselect'
   [CC] res_pjsip/config_transport.c -> res_pjsip/config_transport.o
res_pjsip/config_transport.c: In function ‘cipher_name_to_id’:
res_pjsip/config_transport.c:982: error: ‘PJ_SSL_SOCK_MAX_CIPHERS’ undeclared (first use in this function)
res_pjsip/config_transport.c:982: error: (Each undeclared identifier is reported only once
res_pjsip/config_transport.c:982: error: for each function it appears in.)
res_pjsip/config_transport.c:982: warning: unused variable ‘ciphers’
res_pjsip/config_transport.c: In function ‘handle_pjsip_list_ciphers’:
res_pjsip/config_transport.c:1106: error: ‘PJ_SSL_SOCK_MAX_CIPHERS’ undeclared (first use in this function)
res_pjsip/config_transport.c:1106: warning: unused variable ‘ciphers’
make[1]: *** [res_pjsip/config_transport.o] Error 1
make: *** [res] Error 2
```
So, configure line has been adjusted:
```
diff --git a/freepbx-install.sh b/freepbx-install.sh
index 857d313..8fae00f 100644
--- a/freepbx-install.sh
+++ b/freepbx-install.sh
@@ -77,7 +77,8 @@ tar xvfz asterisk-13-current.tar.gz
 rm -f asterisk-13-current.tar.gz
 cd asterisk-*
 contrib/scripts/install_prereq install
-./configure --libdir=/usr/lib64 --enable-sanitize=memory
+# --with-pjproject-bundled -> https://blogs.asterisk.org/2016/03/16/asterisk-13-8-0-now-easier-pjsip-install-method/
+./configure --libdir=/usr/lib64 --enable-sanitize=memory --with-pjproject-bundled
 contrib/scripts/get_mp3_source.sh
 wait ${!}
 make menuselect.makeopts 
```

2) small glitch in regexp where php.ini should be adjusted
```
diff --git a/freepbx-install.sh b/freepbx-install.sh
index 857d313..f93043d 100644
--- a/freepbx-install.sh
+++ b/freepbx-install.sh
@@ -111,7 +112,7 @@ chown -R asterisk. /var/{lib,log,spool}/asterisk
 chown -R asterisk. /usr/lib64/asterisk
 chown -R asterisk. /var/www/
 
-sed -i 's/\(^upload_max_filesize = \).*/\256M/' /etc/php.ini
+sed -i 's/\(^upload_max_filesize = \).*/\1 256M/' /etc/php.ini
 sed -i 's/^\(User\|Group\).*/\1 asterisk/' /etc/httpd/conf/httpd.conf
 sed -i 's/AllowOverride None/AllowOverride All/' /etc/httpd/conf/httpd.conf
 service httpd restart
```